### PR TITLE
Changed progress_var calculation

### DIFF
--- a/YouTube_Video_Downloader.py
+++ b/YouTube_Video_Downloader.py
@@ -20,7 +20,7 @@ def clear_previous_files(video_file, audio_file):
 
 def progress_hook(d, progress_var, status_var, current_status):
     if d['status'] == 'downloading':
-        progress_var.set(float(d['_percent_str'].strip('%')))
+        progress_var.set((d["downloaded_bytes"]/d["total_bytes"]*100) if d["total_bytes"] is not None else 0.0)
     elif d['status'] == 'finished':
         progress_var.set(100)
         if current_status == 'video':


### PR DESCRIPTION
d['_percent_str'] is used by logs. If app launched from console it will contain special symbols to colourise text. Also it is private variable and shouldn`t be used https://peps.python.org/pep-0008/#method-names-and-instance-variables Example: '\x1b[0;94m 0.0%/x1b[0m'.